### PR TITLE
docs: add env example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Database connection string
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/betterauthtemplate
+
+# Better Auth configuration
+BETTER_AUTH_SECRET=your-super-secret-key-here-change-this-in-production
+BETTER_AUTH_URL=http://localhost:3000
+NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3000
+
+# Email service configuration (Resend)
+RESEND_API_KEY=your-resend-api-key
+RESEND_FROM_EMAIL=noreply@example.com
+

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 .env.local
 
 # vercel

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -2,7 +2,11 @@
 
 ## Required Environment Variables
 
-Create a `.env.local` file in your project root with the following variables:
+Start by copying the example file and then updating the values in your local copy:
+
+```bash
+cp .env.example .env.local
+```
 
 ```bash
 # Database connection string
@@ -11,6 +15,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/betterauthtemplate
 # Better Auth Configuration
 BETTER_AUTH_SECRET=your-super-secret-key-here-change-this-in-production
 BETTER_AUTH_URL=http://localhost:3000
+NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3000
 
 # Email Service Configuration (Resend)
 RESEND_API_KEY=re_your_actual_api_key_here
@@ -22,6 +27,7 @@ RESEND_FROM_EMAIL=noreply@yourdomain.com
 - **DATABASE_URL**: Your PostgreSQL connection string
 - **BETTER_AUTH_SECRET**: A secure random string for JWT signing (generate with `openssl rand -base64 32`)
 - **BETTER_AUTH_URL**: The base URL of your application (optional, defaults to localhost:3000)
+- **NEXT_PUBLIC_BETTER_AUTH_URL**: Base URL exposed to the client for auth requests
 - **RESEND_API_KEY**: Your Resend API key for sending emails (get from resend.com)
 - **RESEND_FROM_EMAIL**: Your verified sender email address
 

--- a/README.md
+++ b/README.md
@@ -38,15 +38,13 @@ A production-ready authentication template built with Next.js, Better Auth, Driz
    ```
 
 2. **Set up environment variables:**
-   Create a `.env.local` file in the root directory:
+   Copy the example file and update the values:
    ```bash
-   # Database connection
-   DATABASE_URL=postgresql://postgres:password@localhost:5432/betterauthtemplate
-   
-   # Better Auth Configuration
-   BETTER_AUTH_SECRET=your-super-secret-key-here-change-this-in-production
-   BETTER_AUTH_URL=http://localhost:3000
+   cp .env.example .env.local
    ```
+   Then edit `.env.local` and replace the placeholder values for variables like
+   `DATABASE_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`,
+   `NEXT_PUBLIC_BETTER_AUTH_URL`, `RESEND_API_KEY`, and `RESEND_FROM_EMAIL`.
 
 3. **Set up the database:**
    ```bash

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -4,6 +4,9 @@ declare global {
       DATABASE_URL: string;
       BETTER_AUTH_SECRET: string;
       BETTER_AUTH_URL?: string;
+      NEXT_PUBLIC_BETTER_AUTH_URL: string;
+      RESEND_API_KEY?: string;
+      RESEND_FROM_EMAIL?: string;
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for required environment variables
- document copying the example file to `.env.local` in setup guides
- include example environment file in version control and extend env typings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 2 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d208a618832aa0a3d59fd39b6425